### PR TITLE
Added support for Scout 6 and Lumen

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,8 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.6.4",
-        "laravel/framework": "5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*",
-        "laravel/scout": "^5.0"
+        "php": ">=7.0",
+        "laravel/scout": "^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Engines/Modes/Mode.php
+++ b/src/Engines/Modes/Mode.php
@@ -13,7 +13,7 @@ abstract class Mode
 
     public function __construct()
     {
-        $this->modelService = resolve(ModelService::class);
+        $this->modelService = app(ModelService::class);
     }
 
     abstract public function buildWhereRawString(Builder $builder);

--- a/src/Engines/MySQLEngine.php
+++ b/src/Engines/MySQLEngine.php
@@ -133,6 +133,17 @@ class MySQLEngine extends Engine
         return $results['count'];
     }
 
+    /**
+     * Flush all of the model's records from the engine.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * 
+     * @return void
+     */
+    public function flush($model) 
+    {
+    }
+
     protected function shouldNotRun($builder)
     {
         return strlen($builder->query) < config('scout.mysql.min_search_length');

--- a/src/Providers/MySQLScoutServiceProvider.php
+++ b/src/Providers/MySQLScoutServiceProvider.php
@@ -24,7 +24,7 @@ class MySQLScoutServiceProvider extends ServiceProvider
         }
 
         $this->app->make(EngineManager::class)->extend('mysql', function () {
-            return new MySQLEngine(resolve(ModeContainer::class));
+            return new MySQLEngine(app(ModeContainer::class));
         });
     }
 


### PR DESCRIPTION
This adds support for Scout 6.x and removes the hard dependency on laravel/framework so that it can also be used with laravel/lumen-framework. Using laravel is implied anyway by using laravel/scout.

Fixes #75 